### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module echo-pprof
+module github.com/robotomize/echov4-pprof
 
 go 1.13
 


### PR DESCRIPTION
go: finding github.com/robotomize/echo-pprof v0.2.1
go: downloading github.com/robotomize/echo-pprof v0.2.1
go: extracting github.com/robotomize/echo-pprof v0.2.1
go: ..deleted...  imports
	github.com/robotomize/echo-pprof: github.com/robotomize/echo-pprof@v0.2.1: parsing go.mod:
	module declares its path as: echo-pprof
	        but was required as: github.com/robotomize/echo-pprof